### PR TITLE
Show dummy list of people in PeopleListFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -25,4 +26,8 @@ dependencies {
      * navigation drawer. */
     implementation "androidx.navigation:navigation-fragment-ktx:2.5.3"
     implementation "androidx.navigation:navigation-ui-ktx:2.5.3"
+
+    // Dagger 2 library. Contains APIs for dependency injection.
+    implementation 'com.google.dagger:dagger:2.44'
+    kapt 'com.google.dagger:dagger-compiler:2.44'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,7 @@ android {
     buildFeatures {
         dataBinding true
     }
+    namespace 'com.davidread.starwarsdatabase'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.davidread.starwarsdatabase">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:name=".di.ApplicationController"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.davidread.starwarsdatabase">
 
     <application
+        android:name=".di.ApplicationController"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="false"

--- a/app/src/main/java/com/davidread/starwarsdatabase/di/ApplicationController.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/di/ApplicationController.kt
@@ -1,0 +1,16 @@
+package com.davidread.starwarsdatabase.di
+
+import android.app.Application
+
+/**
+ * Defines an [Application] subclass that has a dependencies graph for the entire application.
+ */
+class ApplicationController : Application() {
+
+    /**
+     * Dependencies graph for the entire application.
+     */
+    val applicationGraph: ApplicationGraph by lazy {
+        DaggerApplicationGraph.factory().create(applicationContext, this)
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/di/ApplicationGraph.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/di/ApplicationGraph.kt
@@ -1,0 +1,34 @@
+package com.davidread.starwarsdatabase.di
+
+import android.app.Application
+import android.content.Context
+import com.davidread.starwarsdatabase.view.PeopleListFragment
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+/**
+ * Defines the dependencies graph for the entire application.
+ */
+@Singleton
+@Component(modules = [ViewModelModule::class])
+interface ApplicationGraph {
+
+    /**
+     * Factory for creating an instance of this class.
+     */
+    @Component.Factory
+    interface Factory {
+
+        /**
+         * Creates an [ApplicationGraph] instance.
+         */
+        fun create(
+            @BindsInstance context: Context,
+            @BindsInstance application: Application
+        ): ApplicationGraph
+    }
+
+    // Activities and fragments requesting injection.
+    fun inject(fragment: PeopleListFragment)
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/di/ViewModelKey.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/di/ViewModelKey.kt
@@ -1,0 +1,13 @@
+package com.davidread.starwarsdatabase.di
+
+import androidx.lifecycle.ViewModel
+import dagger.MapKey
+import kotlin.reflect.KClass
+
+/**
+ * Annotation that associates a Dagger binds function with a [ViewModel] subclass.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MapKey
+annotation class ViewModelKey(val value: KClass<out ViewModel>)

--- a/app/src/main/java/com/davidread/starwarsdatabase/di/ViewModelModule.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/di/ViewModelModule.kt
@@ -1,0 +1,25 @@
+package com.davidread.starwarsdatabase.di
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.davidread.starwarsdatabase.util.ViewModelFactory
+import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModelImpl
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+
+/**
+ * Defines which [ViewModelProvider.Factory] and [ViewModel] instances to inject for the entire
+ * application.
+ */
+@Module
+abstract class ViewModelModule {
+
+    @Binds
+    abstract fun bindViewModelFactory(viewModelFactory: ViewModelFactory): ViewModelProvider.Factory
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(PeopleListFragmentViewModelImpl::class)
+    abstract fun bindPeopleListFragmentViewModelImpl(viewModel: PeopleListFragmentViewModelImpl): ViewModel
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/PersonListItem.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/PersonListItem.kt
@@ -1,0 +1,25 @@
+package com.davidread.starwarsdatabase.model
+
+/**
+ * Represents a list item that appears in the people list.
+ */
+sealed class PersonListItem {
+
+    /**
+     * Represents a list item for a person.
+     *
+     * @param id Unique identifier for the person from the API.
+     * @param name Person's name.
+     */
+    class PersonItem(val id: Int, val name: String) : PersonListItem()
+
+    /**
+     * Represents a list item for a loading view.
+     */
+    object LoadingItem : PersonListItem()
+
+    /**
+     * Represents a list item for an error view.
+     */
+    object ErrorItem : PersonListItem()
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/util/ViewModelFactory.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/util/ViewModelFactory.kt
@@ -1,0 +1,31 @@
+package com.davidread.starwarsdatabase.util
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import javax.inject.Inject
+import javax.inject.Provider
+
+/**
+ * Utility responsible for instantiating [ViewModel] subclasses in the entire application.
+ */
+class ViewModelFactory @Inject constructor(private val classProviderMap: MutableMap<Class<out ViewModel>, Provider<ViewModel>>) :
+    ViewModelProvider.Factory {
+
+    /**
+     * Creates a new instance of the given `Class`.
+     *
+     * @param modelClass A `Class` whose instance is requested
+     * @return A newly created ViewModel
+     * @throws IllegalArgumentException Thrown if a mapping for [modelClass] doesn't exist in
+     * [classProviderMap].
+     */
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        val viewModelProvider = classProviderMap[modelClass]
+        return viewModelProvider?.let {
+            viewModelProvider.get() as T
+        } ?: run {
+            throw IllegalArgumentException("Unknown ViewModel class $modelClass")
+        }
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
@@ -1,0 +1,126 @@
+package com.davidread.starwarsdatabase.view
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.davidread.starwarsdatabase.databinding.ListItemErrorBinding
+import com.davidread.starwarsdatabase.databinding.ListItemLoadingBinding
+import com.davidread.starwarsdatabase.databinding.ListItemPersonBinding
+import com.davidread.starwarsdatabase.model.PersonListItem
+import com.davidread.starwarsdatabase.view.PeopleListAdapter.ViewType
+
+/**
+ * Binds the [personListItems] dataset into a set of views that are displayed within a
+ * [RecyclerView].
+ *
+ * @param personListItems Dataset for the adapter.
+ * @param onPersonItemClick Function to invoke when a view of type [ViewType.PERSON_ITEM] is
+ * clicked.
+ * @param onErrorItemRetryClick Function to invoke when the retry button of a view of type
+ * [ViewType.ERROR_ITEM] is clicked.
+ */
+class PeopleListAdapter(
+    private val personListItems: List<PersonListItem>,
+    private val onPersonItemClick: (id: Int) -> Unit,
+    private val onErrorItemRetryClick: () -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    /**
+     * Called when [RecyclerView] needs a new [RecyclerView.ViewHolder] of the given type to
+     * represent an item.
+     */
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            ViewType.PERSON_ITEM.ordinal -> {
+                val binding = ListItemPersonBinding.inflate(inflater, parent, false)
+                PersonViewHolder(binding)
+            }
+            ViewType.LOADING_ITEM.ordinal -> {
+                val binding = ListItemLoadingBinding.inflate(inflater, parent, false)
+                LoadingViewHolder(binding)
+            }
+            else -> {
+                val binding = ListItemErrorBinding.inflate(inflater, parent, false)
+                ErrorViewHolder(binding)
+            }
+        }
+    }
+
+    /**
+     * Called by [RecyclerView] to bind data to the [RecyclerView.ViewHolder] to reflect the item at
+     * the given position.
+     */
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is PersonViewHolder -> {
+                val personItem = personListItems[position] as PersonListItem.PersonItem
+                holder.bind(personItem, onPersonItemClick)
+            }
+            is ErrorViewHolder -> {
+                holder.bind(onErrorItemRetryClick)
+            }
+        }
+    }
+
+    /**
+     * Total number of items in the dataset.
+     */
+    override fun getItemCount(): Int = personListItems.size
+
+    /**
+     * Returns the view type of the item at the given position.
+     */
+    override fun getItemViewType(position: Int): Int = when (personListItems[position]) {
+        is PersonListItem.PersonItem -> ViewType.PERSON_ITEM.ordinal
+        is PersonListItem.LoadingItem -> ViewType.LOADING_ITEM.ordinal
+        is PersonListItem.ErrorItem -> ViewType.ERROR_ITEM.ordinal
+    }
+
+    /**
+     * The possible view types of items.
+     */
+    private enum class ViewType {
+        PERSON_ITEM, LOADING_ITEM, ERROR_ITEM
+    }
+
+    /**
+     * Describes a view of type [ViewType.PERSON_ITEM] and metadata about its place within the
+     * [RecyclerView].
+     */
+    private class PersonViewHolder(private val binding: ListItemPersonBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        /**
+         * Binds data to the view held by this [PersonViewHolder].
+         */
+        fun bind(personItem: PersonListItem.PersonItem, onPersonItemClick: (id: Int) -> Unit) {
+            binding.apply {
+                this.personItem = personItem
+                root.setOnClickListener { onPersonItemClick(personItem.id) }
+            }
+        }
+    }
+
+    /**
+     * Describes a view of type [ViewType.LOADING_ITEM] and metadata about its place within the
+     * [RecyclerView].
+     */
+    private class LoadingViewHolder(binding: ListItemLoadingBinding) :
+        RecyclerView.ViewHolder(binding.root)
+
+    /**
+     * Describes a view of type [ViewType.ERROR_ITEM] and metadata about its place within the
+     * [RecyclerView].
+     */
+    private class ErrorViewHolder(private val binding: ListItemErrorBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        /**
+         * Binds data to the view held by this [ErrorViewHolder].
+         */
+        fun bind(onErrorItemRetryClick: () -> Unit) {
+            binding.retryButton.setOnClickListener { onErrorItemRetryClick() }
+        }
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -7,10 +7,12 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.davidread.starwarsdatabase.di.ApplicationController
+import androidx.recyclerview.widget.DividerItemDecoration
 import com.davidread.starwarsdatabase.databinding.FragmentPeopleListBinding
+import com.davidread.starwarsdatabase.di.ApplicationController
 import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModel
 import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModelImpl
+import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 
 /**
@@ -60,11 +62,34 @@ class PeopleListFragment : Fragment() {
     }
 
     /**
-     * Sets up an observer to populate the UI with a dummy string for now.
+     * Sets up an observer to populate the UI with a dummy list for now.
      */
     private fun setupObserver() {
-        viewModel.testLiveData.observe(viewLifecycleOwner) {
-            binding.textView.text = it
+        viewModel.personListItems.observe(viewLifecycleOwner) {
+            binding.peopleList.apply {
+                adapter = PeopleListAdapter(
+                    it,
+                    { id -> onPersonItemClick(id) },
+                    { onErrorItemRetryClick() }
+                )
+                addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+            }
         }
+    }
+
+    /**
+     * Called when a person item is clicked in the list. Does nothing for now.
+     *
+     * @param id Id of the person item clicked.
+     */
+    private fun onPersonItemClick(id: Int) {
+        Snackbar.make(binding.root, "Person click with id=$id", Snackbar.LENGTH_SHORT).show()
+    }
+
+    /**
+     * Called when the retry button of an error item is clicked in the list. Does nothing for now.
+     */
+    private fun onErrorItemRetryClick() {
+        Snackbar.make(binding.root, "Error item retry click", Snackbar.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -1,0 +1,70 @@
+package com.davidread.starwarsdatabase.view
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.davidread.starwarsdatabase.di.ApplicationController
+import com.davidread.starwarsdatabase.databinding.FragmentPeopleListBinding
+import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModel
+import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModelImpl
+import javax.inject.Inject
+
+/**
+ * Fragment representing a list of entries in the people category.
+ */
+class PeopleListFragment : Fragment() {
+
+    /**
+     * Factory for instantiating `ViewModel` instances.
+     */
+    @Inject
+    lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    /**
+     * Binding object for this fragment's layout.
+     */
+    private val binding: FragmentPeopleListBinding by lazy {
+        FragmentPeopleListBinding.inflate(layoutInflater)
+    }
+
+    /**
+     * Exposes state to the UI and encapsulates business logic for this fragment.
+     */
+    private val viewModel: PeopleListFragmentViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[PeopleListFragmentViewModelImpl::class.java]
+    }
+
+    /**
+     * Invoked when this fragment is attached to it's associated activity. It just requests
+     * dependency injection.
+     */
+    override fun onAttach(context: Context) {
+        (activity?.application as ApplicationController).applicationGraph.inject(this)
+        super.onAttach(context)
+    }
+
+    /**
+     * Invoked when this fragment's view is to be created. Sets up some dummy UI for now.
+     */
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        setupObserver()
+        return binding.root
+    }
+
+    /**
+     * Sets up an observer to populate the UI with a dummy string for now.
+     */
+    private fun setupObserver() {
+        viewModel.testLiveData.observe(viewLifecycleOwner) {
+            binding.textView.text = it
+        }
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
@@ -1,0 +1,10 @@
+package com.davidread.starwarsdatabase.viewmodel
+
+import androidx.lifecycle.LiveData
+
+/**
+ * Defines the structure of [PeopleListFragmentViewModelImpl].
+ */
+interface PeopleListFragmentViewModel {
+    val testLiveData: LiveData<String>
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
@@ -1,10 +1,11 @@
 package com.davidread.starwarsdatabase.viewmodel
 
 import androidx.lifecycle.LiveData
+import com.davidread.starwarsdatabase.model.PersonListItem
 
 /**
  * Defines the structure of [PeopleListFragmentViewModelImpl].
  */
 interface PeopleListFragmentViewModel {
-    val testLiveData: LiveData<String>
+    val personListItems: LiveData<List<PersonListItem>>
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -2,11 +2,33 @@ package com.davidread.starwarsdatabase.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.davidread.starwarsdatabase.model.PersonListItem
 import javax.inject.Inject
 
 /**
  * Exposes state and encapsulates business logic related to the people category list.
  */
-class PeopleListFragmentViewModelImpl @Inject constructor() : ViewModel(), PeopleListFragmentViewModel {
-    override val testLiveData = MutableLiveData("This string is emitted from the viewmodel!")
+class PeopleListFragmentViewModelImpl @Inject constructor() : ViewModel(),
+    PeopleListFragmentViewModel {
+
+    /**
+     * Emits a [List] of [PersonListItem]s that should be displayed in the UI.
+     */
+    override val personListItems = MutableLiveData(getDummyList())
+
+    /**
+     * Returns a dummy [List] of [PersonListItem]s.
+     */
+    private fun getDummyList(): List<PersonListItem> = listOf(
+        PersonListItem.PersonItem(1, "Luke Skywalker"),
+        PersonListItem.PersonItem(2, "C-3P0"),
+        PersonListItem.PersonItem(3, "R2-D2"),
+        PersonListItem.PersonItem(4, "Darth Vader"),
+        PersonListItem.PersonItem(5, "Leia Organa"),
+        PersonListItem.PersonItem(6, "Owen Lars"),
+        PersonListItem.PersonItem(7, "Beru Whitesun lars"),
+        PersonListItem.PersonItem(8, "R5-D4"),
+        PersonListItem.PersonItem(9, "Biggs Darklighter"),
+        PersonListItem.PersonItem(10, "Obi-Wan Kenobi")
+    )
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -1,0 +1,12 @@
+package com.davidread.starwarsdatabase.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import javax.inject.Inject
+
+/**
+ * Exposes state and encapsulates business logic related to the people category list.
+ */
+class PeopleListFragmentViewModelImpl @Inject constructor() : ViewModel(), PeopleListFragmentViewModel {
+    override val testLiveData = MutableLiveData("This string is emitted from the viewmodel!")
+}

--- a/app/src/main/res/layout/fragment_empty.xml
+++ b/app/src/main/res/layout/fragment_empty.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".view.EmptyFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_people_list.xml
+++ b/app/src/main/res/layout/fragment_people_list.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_people_list.xml
+++ b/app/src/main/res/layout/fragment_people_list.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".view.PeopleListFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/people_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <TextView
-            android:id="@+id/text_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
 </layout>

--- a/app/src/main/res/layout/list_item_error.xml
+++ b/app/src/main/res/layout/list_item_error.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".view.PeopleListAdapter">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/list_item_padding">
+
+        <TextView
+            android:id="@+id/error_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/fetch_items_error_message"
+            app:layout_constraintBottom_toTopOf="@id/retry_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/retry_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/list_item_error_view_vertical_spacing"
+            android:text="@string/retry_button_label"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/error_message" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/list_item_loading.xml
+++ b/app/src/main/res/layout/list_item_loading.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".view.PeopleListAdapter">
+
+    <ProgressBar
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/list_item_padding" />
+
+</layout>

--- a/app/src/main/res/layout/list_item_person.xml
+++ b/app/src/main/res/layout/list_item_person.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".view.PeopleListAdapter">
+
+    <data>
+
+        <variable
+            name="personItem"
+            type="com.davidread.starwarsdatabase.model.PersonListItem.PersonItem" />
+
+    </data>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:padding="@dimen/list_item_padding"
+        android:text="@{personItem.name}"
+        tools:text="Luke Skywalker" />
+
+</layout>

--- a/app/src/main/res/navigation/nav_graph_category.xml
+++ b/app/src/main/res/navigation/nav_graph_category.xml
@@ -7,16 +7,9 @@
 
     <fragment
         android:id="@+id/people_list_fragment"
-        android:name="com.davidread.starwarsdatabase.view.EmptyFragment"
+        android:name="com.davidread.starwarsdatabase.view.PeopleListFragment"
         android:label="@string/people_list_fragment_name"
-        tools:layout="@layout/fragment_empty">
-
-        <argument
-            android:name="DETAIL_TEXT_RES_ID"
-            android:defaultValue="@string/people_in_empty_fragment_detail_text"
-            app:argType="reference" />
-
-    </fragment>
+        tools:layout="@layout/fragment_people_list" />
 
     <fragment
         android:id="@+id/films_list_fragment"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- List item dimens. -->
+    <dimen name="list_item_padding">16dp</dimen>
+    <dimen name="list_item_error_view_vertical_spacing">8dp</dimen>
+
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,4 +35,8 @@
     <!-- PlanetsListFragment strings. -->
     <string name="planets_list_fragment_name">Planets</string>
 
+    <!-- List item strings. -->
+    <string name="fetch_items_error_message">Error fetching items</string>
+    <string name="retry_button_label">Retry</string>
+
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.application' version '7.2.2' apply false
-    id 'com.android.library' version '7.2.2' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 23 16:59:24 EDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Changelog
- 595a5cfeb0ec6751b6a0b5c2bafa3c89cf268897
    - Setup Dagger dependency injection for the entire app. Define dependencies graph in ```ApplicationGraph.kt```.
    - Setup basic viewmodel + view relationship for ```PeopleListFragment.kt```.
    - Load a ```PeopleListFragment``` instead of an ```EmptyListFragment``` when the people top-level destination is selected.
- 86324c94891d2832ea44e6add9a2b67df084c0f5
    - Modify ```PeopleListFragment.kt``` and create appropriate files to display a ```RecyclerView``` that displays a list of people. Give the ```RecyclerView``` the ability to show loading/error states, too.
    - Have ```PeopleListFragmentViewModel.kt``` emit a dummy list of people to show in the UI for now.
- 0cb91592dc4e78722e85fea804528b29158cb45d
    - Update AGP to 7.3.1.

# Screenshots
- ![Screenshot_20221111_191319](https://user-images.githubusercontent.com/49120229/201446604-10ae11f6-f460-4346-93dd-d973570e569a.png)
- ![Screenshot_20221111_191415](https://user-images.githubusercontent.com/49120229/201446656-63d9bea8-c97e-482e-b26a-6ba2c9ae3746.png)