### PR TITLE
Get PeopleListFragment list data from SWAPI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,4 +31,19 @@ dependencies {
     // Dagger 2 library. Contains APIs for dependency injection.
     implementation 'com.google.dagger:dagger:2.44'
     kapt 'com.google.dagger:dagger-compiler:2.44'
+
+    /* RxJava3 library. Contains APIs for composing asynchronous and event-based programs using
+     * observable sequences. */
+    implementation 'io.reactivex.rxjava3:rxjava:3.1.5'
+    implementation 'io.reactivex.rxjava3:rxandroid:3.0.2'
+
+    // Retrofit 2 library. Is a type-safe HTTP client.
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+
+    /* Retrofit 2 GSON parsing library. Contains APIs for converting between JSON representations
+     * and Kotlin models. */
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+
+    // Retrofit 2 RxJava3 adapter. Contains an API for using RxJava3CallAdapterFactory.
+    implementation 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".di.ApplicationController"
         android:allowBackup="true"

--- a/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.davidread.starwarsdatabase.datasource
 
+import androidx.annotation.IntRange
 import com.davidread.starwarsdatabase.model.datasource.PersonResponse
 import io.reactivex.rxjava3.core.Single
 import retrofit2.http.GET
@@ -14,13 +15,10 @@ interface PeopleRemoteDataSource {
      * Fetches a [PersonResponse] from SWAPI.
      */
     @GET(ENDPOINT_PEOPLE)
-    fun getPeople(@Query(ParameterFormat.NAME) format: String = ParameterFormat.VALUE_JSON): Single<PersonResponse>
+    fun getPeople(@Query(PARAMETER_NAME_PAGE) @IntRange(from = 1) page: Int): Single<PersonResponse>
 
     companion object {
         private const val ENDPOINT_PEOPLE = "people"
-        private object ParameterFormat {
-            const val NAME = "format"
-            const val VALUE_JSON = "json"
-        }
+        private const val PARAMETER_NAME_PAGE = "page"
     }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package com.davidread.starwarsdatabase.datasource
+
+/**
+ * Defines SWAPI endpoints to hit in order to fetch people data.
+ */
+interface PeopleRemoteDataSource {
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
@@ -1,7 +1,26 @@
 package com.davidread.starwarsdatabase.datasource
 
+import com.davidread.starwarsdatabase.model.datasource.PersonResponse
+import io.reactivex.rxjava3.core.Single
+import retrofit2.http.GET
+import retrofit2.http.Query
+
 /**
  * Defines SWAPI endpoints to hit in order to fetch people data.
  */
 interface PeopleRemoteDataSource {
+
+    /**
+     * Fetches a [PersonResponse] from SWAPI.
+     */
+    @GET(ENDPOINT_PEOPLE)
+    fun getPeople(@Query(ParameterFormat.NAME) format: String = ParameterFormat.VALUE_JSON): Single<PersonResponse>
+
+    companion object {
+        private const val ENDPOINT_PEOPLE = "people"
+        private object ParameterFormat {
+            const val NAME = "format"
+            const val VALUE_JSON = "json"
+        }
+    }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/datasource/PeopleRemoteDataSource.kt
@@ -8,11 +8,15 @@ import retrofit2.http.Query
 
 /**
  * Defines SWAPI endpoints to hit in order to fetch people data.
+ *
+ * @see <a href="https://swapi.dev/documentation">SWAPI documentation</a>
  */
 interface PeopleRemoteDataSource {
 
     /**
      * Fetches a [PersonResponse] from SWAPI.
+     *
+     * @param page Which page of people to fetch.
      */
     @GET(ENDPOINT_PEOPLE)
     fun getPeople(@Query(PARAMETER_NAME_PAGE) @IntRange(from = 1) page: Int): Single<PersonResponse>

--- a/app/src/main/java/com/davidread/starwarsdatabase/di/ApplicationGraph.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/di/ApplicationGraph.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
  * Defines the dependencies graph for the entire application.
  */
 @Singleton
-@Component(modules = [ViewModelModule::class])
+@Component(modules = [RemoteDataSourceModule::class, ViewModelModule::class])
 interface ApplicationGraph {
 
     /**

--- a/app/src/main/java/com/davidread/starwarsdatabase/di/RemoteDataSourceModule.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/di/RemoteDataSourceModule.kt
@@ -1,0 +1,30 @@
+package com.davidread.starwarsdatabase.di
+
+import com.davidread.starwarsdatabase.datasource.PeopleRemoteDataSource
+import dagger.Module
+import dagger.Provides
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+
+/**
+ * Defines which [Retrofit] and `[...]RemoteDataSource` instances to inject for the entire application.
+ */
+@Module
+class RemoteDataSourceModule {
+
+    @Provides
+    fun provideRetrofit(): Retrofit = Retrofit.Builder()
+        .baseUrl(SWAPI_BASE_URL)
+        .addConverterFactory(GsonConverterFactory.create())
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
+        .build()
+
+    @Provides
+    fun providePeopleRemoteDataSource(retrofit: Retrofit): PeopleRemoteDataSource =
+        retrofit.create(PeopleRemoteDataSource::class.java)
+
+    companion object {
+        private const val SWAPI_BASE_URL = "https://swapi.dev/api/"
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/Person.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/Person.kt
@@ -1,0 +1,8 @@
+package com.davidread.starwarsdatabase.model.datasource
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a person from SWAPI.
+ */
+data class Person(@SerializedName("name") val name: String, @SerializedName("url") val url: String)

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/Person.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/Person.kt
@@ -4,5 +4,7 @@ import com.google.gson.annotations.SerializedName
 
 /**
  * Represents a person from SWAPI.
+ *
+ * @see <a href="https://swapi.dev/documentation">SWAPI documentation</a>
  */
 data class Person(@SerializedName("name") val name: String, @SerializedName("url") val url: String)

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/PersonResponse.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/PersonResponse.kt
@@ -4,6 +4,8 @@ import com.google.gson.annotations.SerializedName
 
 /**
  * Represents a person response from SWAPI.
+ *
+ * @see <a href="https://swapi.dev/documentation">SWAPI documentation</a>
  */
 data class PersonResponse(
     @SerializedName("results") val results: List<Person>,

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/PersonResponse.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/PersonResponse.kt
@@ -1,0 +1,8 @@
+package com.davidread.starwarsdatabase.model.datasource
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * Represents a person response from SWAPI.
+ */
+data class PersonResponse(@SerializedName("results") val results: List<Person>)

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/PersonResponse.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/datasource/PersonResponse.kt
@@ -5,4 +5,7 @@ import com.google.gson.annotations.SerializedName
 /**
  * Represents a person response from SWAPI.
  */
-data class PersonResponse(@SerializedName("results") val results: List<Person>)
+data class PersonResponse(
+    @SerializedName("results") val results: List<Person>,
+    @SerializedName("next") val next: String?
+)

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/view/PersonListItem.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/view/PersonListItem.kt
@@ -8,8 +8,8 @@ sealed class PersonListItem {
     /**
      * Represents a list item for a person.
      *
-     * @param id Unique identifier for the person from the API.
-     * @param name Person's name.
+     * @property id Unique identifier for the person from the API.
+     * @property name Person's name.
      */
     data class PersonItem(val id: Int, val name: String) : PersonListItem()
 

--- a/app/src/main/java/com/davidread/starwarsdatabase/model/view/PersonListItem.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/view/PersonListItem.kt
@@ -1,4 +1,4 @@
-package com.davidread.starwarsdatabase.model
+package com.davidread.starwarsdatabase.model.view
 
 /**
  * Represents a list item that appears in the people list.
@@ -11,7 +11,7 @@ sealed class PersonListItem {
      * @param id Unique identifier for the person from the API.
      * @param name Person's name.
      */
-    class PersonItem(val id: Int, val name: String) : PersonListItem()
+    data class PersonItem(val id: Int, val name: String) : PersonListItem()
 
     /**
      * Represents a list item for a loading view.

--- a/app/src/main/java/com/davidread/starwarsdatabase/util/Extensions.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/util/Extensions.kt
@@ -1,0 +1,21 @@
+package com.davidread.starwarsdatabase.util
+
+import java.util.regex.Pattern
+
+/**
+ * Takes a [String] that matches the URL `https://swapi.dev/api/{endpoint}/{id}/` and returns the
+ * `{id}` field as an [Int].
+ *
+ * @throws IllegalArgumentException Thrown when the [String] does not match the URL regular
+ * expression.
+ */
+fun String.extractIDFromURL(): Int {
+    val regex = "https://swapi\\.dev/api/[a-z]+/(\\d+)/"
+    val pattern = Pattern.compile(regex)
+    val matcher = pattern.matcher(this)
+    return if (matcher.matches()) {
+        matcher.group(1)!!.toInt()
+    } else {
+        throw IllegalArgumentException("$this must match the regular expression $regex")
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/util/PeopleListAdapterDiffCallback.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/util/PeopleListAdapterDiffCallback.kt
@@ -1,0 +1,30 @@
+package com.davidread.starwarsdatabase.util
+
+import androidx.recyclerview.widget.DiffUtil
+import com.davidread.starwarsdatabase.model.view.PersonListItem
+
+/**
+ * Utility class provided to [com.davidread.starwarsdatabase.view.PeopleListAdapter] that handles
+ * updating the `RecyclerView` when a new dataset is submitted to the adapter.
+ */
+class PeopleListAdapterDiffCallback : DiffUtil.ItemCallback<PersonListItem>() {
+
+    /**
+     * Called to check whether two objects represent the same item.
+     */
+    override fun areItemsTheSame(oldItem: PersonListItem, newItem: PersonListItem): Boolean =
+        if (oldItem is PersonListItem.PersonItem && newItem is PersonListItem.PersonItem) {
+            // Two PersonItems with the same id represent the same item.
+            oldItem.id == newItem.id
+        } else {
+            // Two LoadingItems or two ErrorItems represent the same item.
+            oldItem::class == newItem::class
+        }
+
+    /**
+     * Called to check if two items have the same data. Items have static content, so this function
+     * defaults to `true`.
+     */
+    override fun areContentsTheSame(oldItem: PersonListItem, newItem: PersonListItem): Boolean =
+        true
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/CategoryActivity.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/CategoryActivity.kt
@@ -18,7 +18,7 @@ import com.davidread.starwarsdatabase.databinding.ActivityCategoryBinding
 class CategoryActivity : AppCompatActivity(), NavController.OnDestinationChangedListener {
 
     /**
-     * Allows easy access to view objects from the layout.
+     * Binding object for this activity's layout.
      */
     private val binding: ActivityCategoryBinding by lazy {
         ActivityCategoryBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/EmptyFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/EmptyFragment.kt
@@ -13,7 +13,7 @@ import com.davidread.starwarsdatabase.databinding.FragmentEmptyBinding
 class EmptyFragment : Fragment() {
 
     /**
-     * Allows easy access to view objects from the layout.
+     * Binding object for this fragment's layout.
      */
     private val binding: FragmentEmptyBinding by lazy {
         FragmentEmptyBinding.inflate(layoutInflater)

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
@@ -15,9 +15,9 @@ import com.davidread.starwarsdatabase.view.PeopleListAdapter.ViewType
  * Binds a [List] of [PersonListItem] dataset into a set of views that are displayed within a
  * [RecyclerView].
  *
- * @param onPersonItemClick Function to invoke when a view of type [ViewType.PERSON_ITEM] is
+ * @property onPersonItemClick Function to invoke when a view of type [ViewType.PERSON_ITEM] is
  * clicked.
- * @param onErrorItemRetryClick Function to invoke when the retry button of a view of type
+ * @property onErrorItemRetryClick Function to invoke when the retry button of a view of type
  * [ViewType.ERROR_ITEM] is clicked.
  */
 class PeopleListAdapter(

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
@@ -20,7 +20,7 @@ import com.davidread.starwarsdatabase.view.PeopleListAdapter.ViewType
  * [ViewType.ERROR_ITEM] is clicked.
  */
 class PeopleListAdapter(
-    private val personListItems: List<PersonListItem>,
+    var personListItems: List<PersonListItem>,
     private val onPersonItemClick: (id: Int) -> Unit,
     private val onErrorItemRetryClick: () -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -80,7 +80,7 @@ class PeopleListAdapter(
     /**
      * The possible view types of items.
      */
-    private enum class ViewType {
+    enum class ViewType {
         PERSON_ITEM, LOADING_ITEM, ERROR_ITEM
     }
 

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
@@ -2,28 +2,28 @@ package com.davidread.starwarsdatabase.view
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.davidread.starwarsdatabase.databinding.ListItemErrorBinding
 import com.davidread.starwarsdatabase.databinding.ListItemLoadingBinding
 import com.davidread.starwarsdatabase.databinding.ListItemPersonBinding
 import com.davidread.starwarsdatabase.model.view.PersonListItem
+import com.davidread.starwarsdatabase.util.PeopleListAdapterDiffCallback
 import com.davidread.starwarsdatabase.view.PeopleListAdapter.ViewType
 
 /**
- * Binds the [personListItems] dataset into a set of views that are displayed within a
+ * Binds a [List] of [PersonListItem] dataset into a set of views that are displayed within a
  * [RecyclerView].
  *
- * @param personListItems Dataset for the adapter.
  * @param onPersonItemClick Function to invoke when a view of type [ViewType.PERSON_ITEM] is
  * clicked.
  * @param onErrorItemRetryClick Function to invoke when the retry button of a view of type
  * [ViewType.ERROR_ITEM] is clicked.
  */
 class PeopleListAdapter(
-    var personListItems: List<PersonListItem>,
     private val onPersonItemClick: (id: Int) -> Unit,
     private val onErrorItemRetryClick: () -> Unit
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : ListAdapter<PersonListItem, RecyclerView.ViewHolder>(PeopleListAdapterDiffCallback()) {
 
     /**
      * Called when [RecyclerView] needs a new [RecyclerView.ViewHolder] of the given type to
@@ -54,7 +54,7 @@ class PeopleListAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is PersonViewHolder -> {
-                val personItem = personListItems[position] as PersonListItem.PersonItem
+                val personItem = getItem(position) as PersonListItem.PersonItem
                 holder.bind(personItem, onPersonItemClick)
             }
             is ErrorViewHolder -> {
@@ -64,14 +64,9 @@ class PeopleListAdapter(
     }
 
     /**
-     * Total number of items in the dataset.
-     */
-    override fun getItemCount(): Int = personListItems.size
-
-    /**
      * Returns the view type of the item at the given position.
      */
-    override fun getItemViewType(position: Int): Int = when (personListItems[position]) {
+    override fun getItemViewType(position: Int): Int = when (getItem(position)) {
         is PersonListItem.PersonItem -> ViewType.PERSON_ITEM.ordinal
         is PersonListItem.LoadingItem -> ViewType.LOADING_ITEM.ordinal
         is PersonListItem.ErrorItem -> ViewType.ERROR_ITEM.ordinal

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListAdapter.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.davidread.starwarsdatabase.databinding.ListItemErrorBinding
 import com.davidread.starwarsdatabase.databinding.ListItemLoadingBinding
 import com.davidread.starwarsdatabase.databinding.ListItemPersonBinding
-import com.davidread.starwarsdatabase.model.PersonListItem
+import com.davidread.starwarsdatabase.model.view.PersonListItem
 import com.davidread.starwarsdatabase.view.PeopleListAdapter.ViewType
 
 /**

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -101,9 +101,10 @@ class PeopleListFragment : Fragment() {
     }
 
     /**
-     * Sets up an observer to the [PeopleListAdapter]'s dataset. First, it updates the adapter with
-     * the latest dataset from the [viewModel]. Then, it takes some action depending on the last
-     * item in the dataset.
+     * Sets up an observer to the [PeopleListAdapter]'s dataset. It sets up two observers. The first
+     * one is responsible for updating the adapter with the latest dataset from the [viewModel]. The
+     * second is responsible for removing the scroll listener from the [RecyclerView] when no more
+     * entries may be fetched for the dataset.
      */
     private fun setupObserver() {
         viewModel.personListItemsLiveData.observe(viewLifecycleOwner) { personListItems ->
@@ -119,6 +120,12 @@ class PeopleListFragment : Fragment() {
                     binding.peopleList.smoothScrollToPosition(personListItems.lastIndex)
                 }
                 else -> {}
+            }
+        }
+
+        viewModel.isAllPersonListItemsRequestedLiveData.observe(viewLifecycleOwner) { isAllPersonListItemsRequested ->
+            if (isAllPersonListItemsRequested) {
+                binding.peopleList.removeOnScrollListener(loadMorePeopleOnScrollListener)
             }
         }
     }

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -140,9 +140,11 @@ class PeopleListFragment : Fragment() {
     }
 
     /**
-     * Called when the retry button of an error item is clicked in the list. Does nothing for now.
+     * Called when the retry button of an error item is clicked in the list. It requests more
+     * people from the [viewModel] to be added onto the dataset from SWAPI.
      */
     private fun onErrorItemRetryClick() {
-        Snackbar.make(binding.root, "Error item retry click", Snackbar.LENGTH_SHORT).show()
+        val page = ((peopleListAdapter.itemCount - 2) / 10) + 2
+        viewModel.getPeople(page)
     }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -62,10 +62,10 @@ class PeopleListFragment : Fragment() {
     }
 
     /**
-     * Sets up an observer to populate the UI with a dummy list for now.
+     * Sets up an observer to populate the UI with a simple list from SWAPI for now.
      */
     private fun setupObserver() {
-        viewModel.personListItems.observe(viewLifecycleOwner) {
+        viewModel.personListItemsLiveData.observe(viewLifecycleOwner) {
             binding.peopleList.apply {
                 adapter = PeopleListAdapter(
                     it,

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
@@ -8,5 +8,6 @@ import com.davidread.starwarsdatabase.model.view.PersonListItem
  */
 interface PeopleListFragmentViewModel {
     val personListItemsLiveData: LiveData<List<PersonListItem>>
+    val isAllPersonListItemsRequestedLiveData: LiveData<Boolean>
     fun getPeople(page: Int)
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
@@ -7,5 +7,5 @@ import com.davidread.starwarsdatabase.model.view.PersonListItem
  * Defines the structure of [PeopleListFragmentViewModelImpl].
  */
 interface PeopleListFragmentViewModel {
-    val personListItems: LiveData<List<PersonListItem>>
+    val personListItemsLiveData: LiveData<List<PersonListItem>>
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
@@ -1,7 +1,7 @@
 package com.davidread.starwarsdatabase.viewmodel
 
 import androidx.lifecycle.LiveData
-import com.davidread.starwarsdatabase.model.PersonListItem
+import com.davidread.starwarsdatabase.model.view.PersonListItem
 
 /**
  * Defines the structure of [PeopleListFragmentViewModelImpl].

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModel.kt
@@ -8,4 +8,5 @@ import com.davidread.starwarsdatabase.model.view.PersonListItem
  */
 interface PeopleListFragmentViewModel {
     val personListItemsLiveData: LiveData<List<PersonListItem>>
+    fun getPeople(page: Int)
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -2,14 +2,18 @@ package com.davidread.starwarsdatabase.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.davidread.starwarsdatabase.datasource.PeopleRemoteDataSource
 import com.davidread.starwarsdatabase.model.view.PersonListItem
 import javax.inject.Inject
 
 /**
  * Exposes state and encapsulates business logic related to the people category list.
+ *
+ * @property peopleRemoteDataSource [PeopleRemoteDataSource] implementation by `Retrofit` for
+ * fetching people data from SWAPI.
  */
-class PeopleListFragmentViewModelImpl @Inject constructor() : ViewModel(),
-    PeopleListFragmentViewModel {
+class PeopleListFragmentViewModelImpl @Inject constructor(private val peopleRemoteDataSource: PeopleRemoteDataSource) :
+    ViewModel(), PeopleListFragmentViewModel {
 
     /**
      * Emits a [List] of [PersonListItem]s that should be displayed in the UI.

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -27,6 +27,11 @@ class PeopleListFragmentViewModelImpl @Inject constructor(private val peopleRemo
     override val personListItemsLiveData = MutableLiveData(listOf<PersonListItem>())
 
     /**
+     * Whether all [PersonListItem]s have been fetched from SWAPI.
+     */
+    override val isAllPersonListItemsRequestedLiveData = MutableLiveData(false)
+
+    /**
      * Container for managing resources used by `Disposable`s or their subclasses.
      */
     private val disposable: CompositeDisposable = CompositeDisposable()
@@ -76,6 +81,9 @@ class PeopleListFragmentViewModelImpl @Inject constructor(private val peopleRemo
                     personListItems.remove(PersonListItem.LoadingItem)
                     personListItems.addAll(newPersonItems)
                     personListItemsLiveData.postValue(personListItems)
+                    if (personResponse.next == null) {
+                        isAllPersonListItemsRequestedLiveData.postValue(true)
+                    }
                 },
                 { throwable ->
                     personListItems.remove(PersonListItem.LoadingItem)

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -2,7 +2,7 @@ package com.davidread.starwarsdatabase.viewmodel
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.davidread.starwarsdatabase.model.PersonListItem
+import com.davidread.starwarsdatabase.model.view.PersonListItem
 import javax.inject.Inject
 
 /**

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -1,9 +1,14 @@
 package com.davidread.starwarsdatabase.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.davidread.starwarsdatabase.datasource.PeopleRemoteDataSource
 import com.davidread.starwarsdatabase.model.view.PersonListItem
+import com.davidread.starwarsdatabase.util.extractIDFromURL
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import io.reactivex.rxjava3.schedulers.Schedulers
 import javax.inject.Inject
 
 /**
@@ -18,21 +23,49 @@ class PeopleListFragmentViewModelImpl @Inject constructor(private val peopleRemo
     /**
      * Emits a [List] of [PersonListItem]s that should be displayed in the UI.
      */
-    override val personListItems = MutableLiveData(getDummyList())
+    override val personListItemsLiveData = MutableLiveData<List<PersonListItem>>()
 
     /**
-     * Returns a dummy [List] of [PersonListItem]s.
+     * Container for managing resources used by `Disposable`s or their subclasses.
      */
-    private fun getDummyList(): List<PersonListItem> = listOf(
-        PersonListItem.PersonItem(1, "Luke Skywalker"),
-        PersonListItem.PersonItem(2, "C-3P0"),
-        PersonListItem.PersonItem(3, "R2-D2"),
-        PersonListItem.PersonItem(4, "Darth Vader"),
-        PersonListItem.PersonItem(5, "Leia Organa"),
-        PersonListItem.PersonItem(6, "Owen Lars"),
-        PersonListItem.PersonItem(7, "Beru Whitesun lars"),
-        PersonListItem.PersonItem(8, "R5-D4"),
-        PersonListItem.PersonItem(9, "Biggs Darklighter"),
-        PersonListItem.PersonItem(10, "Obi-Wan Kenobi")
-    )
+    private val disposable: CompositeDisposable = CompositeDisposable()
+
+    /**
+     * Called when this `ViewModel` is initialized. It sets up a subscription for getting a simple
+     * list of people from SWAPI to show in the UI.
+     */
+    init {
+        disposable.add(peopleRemoteDataSource.getPeople()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(Schedulers.io())
+            .doOnSubscribe {
+                personListItemsLiveData.postValue(listOf(PersonListItem.LoadingItem))
+            }
+            .subscribe(
+                { personResponse ->
+                    val personListItems = personResponse.results.map { person ->
+                        PersonListItem.PersonItem(person.url.extractIDFromURL(), person.name)
+                    }
+                    personListItemsLiveData.postValue(personListItems)
+                },
+                { throwable ->
+                    personListItemsLiveData.postValue(listOf(PersonListItem.ErrorItem))
+                    Log.e(TAG, throwable.toString())
+                }
+            )
+        )
+    }
+
+    /**
+     * Called when this `ViewModel` is no longer used and will be destroyed. Clears any
+     * subscriptions held by [disposable] to prevent this `ViewModel` from leaking.
+     */
+    override fun onCleared() {
+        disposable.clear()
+        super.onCleared()
+    }
+
+    companion object {
+        private const val TAG = "PeopleListFragmentViewModelImpl"
+    }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImpl.kt
@@ -70,7 +70,10 @@ class PeopleListFragmentViewModelImpl @Inject constructor(private val peopleRemo
             .observeOn(AndroidSchedulers.mainThread())
             .subscribeOn(Schedulers.io())
             .doOnSubscribe {
-                personListItems.add(PersonListItem.LoadingItem)
+                personListItems.apply {
+                    remove(PersonListItem.ErrorItem)
+                    add(PersonListItem.LoadingItem)
+                }
                 personListItemsLiveData.postValue(personListItems)
             }
             .subscribe(
@@ -78,16 +81,20 @@ class PeopleListFragmentViewModelImpl @Inject constructor(private val peopleRemo
                     val newPersonItems = personResponse.results.map { person ->
                         PersonListItem.PersonItem(person.url.extractIDFromURL(), person.name)
                     }
-                    personListItems.remove(PersonListItem.LoadingItem)
-                    personListItems.addAll(newPersonItems)
+                    personListItems.apply {
+                        remove(PersonListItem.LoadingItem)
+                        addAll(newPersonItems)
+                    }
                     personListItemsLiveData.postValue(personListItems)
                     if (personResponse.next == null) {
                         isAllPersonListItemsRequestedLiveData.postValue(true)
                     }
                 },
                 { throwable ->
-                    personListItems.remove(PersonListItem.LoadingItem)
-                    personListItems.add(PersonListItem.ErrorItem)
+                    personListItems.apply {
+                        remove(PersonListItem.LoadingItem)
+                        add(PersonListItem.ErrorItem)
+                    }
                     personListItemsLiveData.postValue(personListItems)
                     Log.e(TAG, throwable.toString())
                 }

--- a/app/src/main/res/layout/list_item_person.xml
+++ b/app/src/main/res/layout/list_item_person.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="personItem"
-            type="com.davidread.starwarsdatabase.model.PersonListItem.PersonItem" />
+            type="com.davidread.starwarsdatabase.model.view.PersonListItem.PersonItem" />
 
     </data>
 


### PR DESCRIPTION
# Changelog
- 80fe31443ea5f2711e714a0fa31c5fa1a54e1b53
    - Add dependencies required to use RxJava and Retrofit.
- a545eb2bd3faae7344a68ef9803a919fed59ae7e
    - Move ```PeopleListItem.kt``` into the ```model/view``` package.
    - Use data modifier for ```PersonItem``` class.
- 1fbd73da1f54cd99fad4e4d8de9e419d985bb73b
    - Setup dependency injection for ```PeopleRemoteDataSource.kt```.
- 810020c0de95283c284b333087385a302faf7c6f
    - Fetch first 10 people from SWAPI and display in ```PeopleListFragment```.
- 52eaf945cbded0bdecf408b1e5cee6dcad962aec
    - Fetch 10 more people from SWAPI whenever the bottom of the list is reached in ```PeopleListFragment```.
- 54a7bf69f1b66c8f9ae6c88a3fd5e82a08bfecd3
    - Use ```PeopleListAdapterDiffCallback.kt``` to handle ```RecyclerView``` updates instead of ```notifyDatasetChanged()```.
    - Fix bug where multiple requests for the same SWAPI page is made.
- 504c35fdc150f3673e21feb94c556398ee56690e
    - Fix bug where error view would show at the end of a list in ```PeopleListFragment```.
- 9fc364e716b776e4b46227045f34774b37f8263a
    - Improve KDocs.
- 4fa2ed6046a2b1275a554c02bfad42ce7305cea8
    - Implement retry option for when an SWAPI request fails in ```PeopleListFragment```.

# Screenshots
- ![Screenshot_20221119_182631](https://user-images.githubusercontent.com/49120229/202875541-2af6bec3-7d52-423d-bf4f-8a59330f3d7a.png)
- ![Screenshot_20221119_182705](https://user-images.githubusercontent.com/49120229/202875540-b3987881-72d2-4673-9772-bb188ed5a19e.png)
- ![Screenshot_20221119_182731](https://user-images.githubusercontent.com/49120229/202875539-2d9f163f-3863-4da7-98dc-97f921ab8056.png)