### PR TITLE
Unit test PeopleListFragmentViewModelImpl

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,4 +46,10 @@ dependencies {
 
     // Retrofit 2 RxJava3 adapter. Contains an API for using RxJava3CallAdapterFactory.
     implementation 'com.squareup.retrofit2:adapter-rxjava3:2.9.0'
+
+    // Mocking library for Kotlin.
+    testImplementation 'io.mockk:mockk:1.13.2'
+
+    // Contains APIs with JUnit test rules that can be used with LiveData.
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
 }

--- a/app/src/test/java/com/davidread/starwarsdatabase/RxImmediateSchedulerRule.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/RxImmediateSchedulerRule.kt
@@ -1,0 +1,34 @@
+package com.davidread.starwarsdatabase
+
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
+import io.reactivex.rxjava3.plugins.RxJavaPlugins
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * A [TestRule] that overrides RxJava's default scheduler behavior. Instead of executing it's load
+ * on a background thread, it it forces it to execute it's load on the main thread.
+ */
+class RxImmediateSchedulerRule : TestRule {
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            @Throws(Throwable::class)
+            override fun evaluate() {
+                RxJavaPlugins.setIoSchedulerHandler { Schedulers.trampoline() }
+                RxJavaPlugins.setComputationSchedulerHandler { Schedulers.trampoline() }
+                RxJavaPlugins.setNewThreadSchedulerHandler { Schedulers.trampoline() }
+                RxAndroidPlugins.setInitMainThreadSchedulerHandler { Schedulers.trampoline() }
+
+                try {
+                    base.evaluate()
+                } finally {
+                    RxJavaPlugins.reset()
+                    RxAndroidPlugins.reset()
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImplTest.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PeopleListFragmentViewModelImplTest.kt
@@ -1,0 +1,112 @@
+package com.davidread.starwarsdatabase.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.davidread.starwarsdatabase.RxImmediateSchedulerRule
+import com.davidread.starwarsdatabase.datasource.PeopleRemoteDataSource
+import com.davidread.starwarsdatabase.model.datasource.Person
+import com.davidread.starwarsdatabase.model.datasource.PersonResponse
+import com.davidread.starwarsdatabase.model.view.PersonListItem
+import io.mockk.every
+import io.mockk.mockk
+import io.reactivex.rxjava3.core.Single
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Unit tests that verify the correctness of [PeopleListFragmentViewModelImpl].
+ */
+class PeopleListFragmentViewModelImplTest {
+
+    /**
+     * Rule that swaps the background executor used by the Architecture Components with one that
+     * executes each task synchronously.
+     */
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    /**
+     * Rule that forces RxJava to execute it's load on the main thread.
+     */
+    @Rule
+    @JvmField
+    val testSchedulerRule = RxImmediateSchedulerRule()
+
+    @Test
+    fun `given datasource that returns success response, when viewmodel calls init, then viewmodel emits 10 person items in the UI list`() {
+        val response = getSuccessfulPersonResponse()
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.just(response)
+        }
+        val viewModel = PeopleListFragmentViewModelImpl(dataSource)
+
+        val actualList = viewModel.personListItemsLiveData.value
+        Assert.assertEquals(response.results.size, actualList!!.size)
+        for (item in actualList) {
+            Assert.assertTrue(item is PersonListItem.PersonItem)
+        }
+    }
+
+    @Test
+    fun `given datasource that returns error response, when viewmodel calls init, then viewmodel emits an error item in the UI list`() {
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.error(Throwable())
+        }
+        val viewModel = PeopleListFragmentViewModelImpl(dataSource)
+
+        val actualList = viewModel.personListItemsLiveData.value
+        Assert.assertEquals(1, actualList!!.size)
+        Assert.assertTrue(actualList.first() is PersonListItem.ErrorItem)
+    }
+
+    @Test
+    fun `given datasource that returns a non-null next status, when viewmodel calls init, then viewmodel emits list not full status`() {
+        val next = "https://swapi.dev/api/people/?page=2"
+        val response = getSuccessfulPersonResponse(next)
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.just(response)
+        }
+        val viewModel = PeopleListFragmentViewModelImpl(dataSource)
+
+        Assert.assertFalse(viewModel.isAllPersonListItemsRequestedLiveData.value!!)
+    }
+
+    @Test
+    fun `given datasource that returns a null next status, when viewmodel calls init, then viewmodel emits list full status`() {
+        val next = null
+        val response = getSuccessfulPersonResponse(next)
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.just(response)
+        }
+        val viewModel = PeopleListFragmentViewModelImpl(dataSource)
+
+        Assert.assertTrue(viewModel.isAllPersonListItemsRequestedLiveData.value!!)
+    }
+
+    @Test
+    fun `given datasource that returns error response, when viewmodel calls init, then viewmodel emits list not full status`() {
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.error(Throwable())
+        }
+        val viewModel = PeopleListFragmentViewModelImpl(dataSource)
+
+        Assert.assertFalse(viewModel.isAllPersonListItemsRequestedLiveData.value!!)
+    }
+
+    private fun getSuccessfulPersonResponse(next: String? = null) = PersonResponse(
+        listOf(
+            Person("Luke Skywalker", "https://swapi.dev/api/people/1/"),
+            Person("C-3PO", "https://swapi.dev/api/people/2/"),
+            Person("R2-D2", "https://swapi.dev/api/people/3/"),
+            Person("Darth Vader", "https://swapi.dev/api/people/4/"),
+            Person("Leia Organa", "https://swapi.dev/api/people/5/"),
+            Person("Owen Lars", "https://swapi.dev/api/people/6/"),
+            Person("Owen Lars", "https://swapi.dev/api/people/7/"),
+            Person("R5-D4", "https://swapi.dev/api/people/8/"),
+            Person("Biggs Darklighter", "https://swapi.dev/api/people/9/"),
+            Person("Obi-Wan Kenobi", "https://swapi.dev/api/people/10/")
+        ),
+        next
+    )
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,9 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx512m -Dfile.encoding=UTF-8
+# Specifies path to Java Home.
+org.gradle.java.home=C\:\\Program Files\\Android\\Android Studio\\jre
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
# Changelog
- cfff16a11892c27e924bd141f076968f5e1a18fa
    - Add unit testing dependencies.
- 5be61359a496014dc94021ccbcf4955e973cdd2e
    - Define ```RxImmediateSchedulerRule.kt```, a test rule that forces RxJava to run it's load on the main thread for unit testing.
- 2080b60e040ffb13dde86ec9c9d8b1196d87ac62
    - Define unit tests for ```PeopleListFragmentViewModelImpl.kt```.
- 3e2aa1b20cba003558ac234a2e4854f430da0aa2
    - Tweak ```gradle.properties``` file to fix errors occurring when ./gradlew commands are executed in Terminal. Errors were related to heap size and incorrect JDK version being consumed.