### PR TITLE
Show dummy list of person details in PersonDetailFragment

### DIFF
--- a/app/src/main/java/com/davidread/starwarsdatabase/model/view/DetailListItem.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/model/view/DetailListItem.kt
@@ -1,0 +1,9 @@
+package com.davidread.starwarsdatabase.model.view
+
+/**
+ * Represents a list item that appears in any detail list.
+ *
+ * @property label Detail's label.
+ * @property value Detail's value.
+ */
+data class DetailListItem(val label: String, val value: String)

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/CategoryActivity.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/CategoryActivity.kt
@@ -34,17 +34,21 @@ class CategoryActivity : AppCompatActivity(), NavController.OnDestinationChanged
     }
 
     /**
+     * Set of id resources that represent top-level fragment destinations in the nav controller.
+     */
+    private val topLevelDestinations: Set<Int> = setOf(
+        R.id.people_list_fragment,
+        R.id.films_list_fragment,
+        R.id.starships_list_fragment,
+        R.id.vehicles_list_fragment,
+        R.id.species_list_fragment,
+        R.id.planets_list_fragment
+    )
+
+    /**
      * Manages the behavior of the navigation drawer button in the action bar.
      */
     private val appBarConfiguration: AppBarConfiguration by lazy {
-        val topLevelDestinations = setOf(
-            R.id.people_list_fragment,
-            R.id.films_list_fragment,
-            R.id.starships_list_fragment,
-            R.id.vehicles_list_fragment,
-            R.id.species_list_fragment,
-            R.id.planets_list_fragment
-        )
         AppBarConfiguration(topLevelDestinations, binding.drawerLayout)
     }
 
@@ -91,15 +95,28 @@ class CategoryActivity : AppCompatActivity(), NavController.OnDestinationChanged
     }
 
     /**
-     * Invoked when the [navController] shows a new fragment. It calls this because [drawerToggle]
-     * is not notified to update the navigation drawer button when a navigation drawer option is
-     * selected.
+     * Invoked when the up button in the action bar is selected. It passes this event to
+     * [navController] to handle first. If not handled, then the superclass handles it.
+     */
+    override fun onSupportNavigateUp(): Boolean {
+        return navController.navigateUp() || super.onSupportNavigateUp()
+    }
+
+    /**
+     * Invoked when the [navController] shows a new fragment. It determines whether to show the
+     * drawer toggle in the action bar and whether to sync the drawer toggle's state with it's
+     * drawer layout.
      */
     override fun onDestinationChanged(
         controller: NavController,
         destination: NavDestination,
         arguments: Bundle?
     ) {
-        drawerToggle.syncState()
+        if (topLevelDestinations.contains(destination.id)) {
+            drawerToggle.isDrawerIndicatorEnabled = true
+            drawerToggle.syncState()
+        } else {
+            drawerToggle.isDrawerIndicatorEnabled = false
+        }
     }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/DetailListAdapter.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/DetailListAdapter.kt
@@ -1,0 +1,54 @@
+package com.davidread.starwarsdatabase.view
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.davidread.starwarsdatabase.databinding.ListItemDetailBinding
+import com.davidread.starwarsdatabase.model.view.DetailListItem
+
+/**
+ * Binds a [List] of [DetailListItem] into a set of views that are displayed within a
+ * [RecyclerView].
+ *
+ * @property detailListItems Data source for the list.
+ */
+class DetailListAdapter(private val detailListItems: List<DetailListItem>) :
+    RecyclerView.Adapter<DetailListAdapter.DetailViewHolder>() {
+
+    /**
+     * Called when [RecyclerView] needs a new [DetailViewHolder] to represent an item.
+     */
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ListItemDetailBinding.inflate(inflater, parent, false)
+        return DetailViewHolder(binding)
+    }
+
+    /**
+     * Called by [RecyclerView] to bind data to the [DetailViewHolder] to reflect the item at
+     * the given position.
+     */
+    override fun onBindViewHolder(holder: DetailViewHolder, position: Int) {
+        val detailItem = detailListItems[position]
+        holder.bind(detailItem)
+    }
+
+    /**
+     * Returns the count of items in the data source.
+     */
+    override fun getItemCount(): Int = detailListItems.size
+
+    /**
+     * Describes a detail view and metadata about its place within the [RecyclerView].
+     */
+    class DetailViewHolder(private val binding: ListItemDetailBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        /**
+         * Binds data to the view held by this [DetailViewHolder].
+         */
+        fun bind(detailItem: DetailListItem) {
+            binding.detailItem = detailItem
+        }
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -7,15 +7,16 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.davidread.starwarsdatabase.R
 import com.davidread.starwarsdatabase.databinding.FragmentPeopleListBinding
 import com.davidread.starwarsdatabase.di.ApplicationController
 import com.davidread.starwarsdatabase.model.view.PersonListItem
 import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModel
 import com.davidread.starwarsdatabase.viewmodel.PeopleListFragmentViewModelImpl
-import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 
 /**
@@ -131,12 +132,12 @@ class PeopleListFragment : Fragment() {
     }
 
     /**
-     * Called when a person item is clicked in the list. Does nothing for now.
+     * Called when a person item is clicked in the list. Doesn't do much for now.
      *
      * @param id Id of the person item clicked.
      */
     private fun onPersonItemClick(id: Int) {
-        Snackbar.make(binding.root, "Person click with id=$id", Snackbar.LENGTH_SHORT).show()
+        findNavController().navigate(R.id.action_peopleListFragment_to_personDetailFragment)
     }
 
     /**

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PeopleListFragment.kt
@@ -102,6 +102,15 @@ class PeopleListFragment : Fragment() {
     }
 
     /**
+     * Invoked when this fragment's view is to be destroyed. It removes the on scroll listener so
+     * duplicate requests don't happen when the user navigates back to this fragment.
+     */
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.peopleList.removeOnScrollListener(loadMorePeopleOnScrollListener)
+    }
+
+    /**
      * Sets up an observer to the [PeopleListAdapter]'s dataset. It sets up two observers. The first
      * one is responsible for updating the adapter with the latest dataset from the [viewModel]. The
      * second is responsible for removing the scroll listener from the [RecyclerView] when no more

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailFragment.kt
@@ -1,0 +1,32 @@
+package com.davidread.starwarsdatabase.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.davidread.starwarsdatabase.databinding.FragmentPersonDetailBinding
+
+/**
+ * Fragment representing the detail view of a person.
+ */
+class PersonDetailFragment : Fragment() {
+
+    /**
+     * Binding object for this fragment's layout.
+     */
+    private val binding: FragmentPersonDetailBinding by lazy {
+        FragmentPersonDetailBinding.inflate(layoutInflater)
+    }
+
+    /**
+     * Invoked when this fragment's view is to be created. Does nothing for now.
+     */
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailFragment.kt
@@ -5,7 +5,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.DividerItemDecoration
+import com.davidread.starwarsdatabase.R
 import com.davidread.starwarsdatabase.databinding.FragmentPersonDetailBinding
+import com.davidread.starwarsdatabase.model.view.DetailListItem
 
 /**
  * Fragment representing the detail view of a person.
@@ -20,13 +23,36 @@ class PersonDetailFragment : Fragment() {
     }
 
     /**
-     * Invoked when this fragment's view is to be created. Does nothing for now.
+     * Invoked when this fragment's view is to be created. It initializes the details list with
+     * dummy data and returns the fragment's view.
      */
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        val dummyDetailListItems = listOf(
+            DetailListItem(getString(R.string.name_detail_label), "Luke Skywalker"),
+            DetailListItem(getString(R.string.homeworld_detail_label), "Tatooine"),
+            DetailListItem(getString(R.string.birth_year_detail_label), "19BBY"),
+            DetailListItem(getString(R.string.species_detail_label), ""),
+            DetailListItem(getString(R.string.gender_detail_label), "male"),
+            DetailListItem(getString(R.string.height_detail_label), "172"),
+            DetailListItem(getString(R.string.mass_detail_label), "77"),
+            DetailListItem(getString(R.string.hair_color_detail_label), "blond"),
+            DetailListItem(getString(R.string.eye_color_detail_label), "blue"),
+            DetailListItem(getString(R.string.skin_color_detail_label), "fair"),
+            DetailListItem(
+                getString(R.string.films_detail_label),
+                "A New Hope, The Empire Strikes Back, Return of the Jedi, Revenge of the Sith"
+            ),
+            DetailListItem(getString(R.string.starships_detail_label), "X-wing, Imperial shuttle"),
+            DetailListItem(getString(R.string.vehicles_detail_label), "Snowspeeder, Imperial Speeder Bike")
+        )
+        binding.personDetailList.apply {
+            adapter = DetailListAdapter(dummyDetailListItems)
+            addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+        }
         return binding.root
     }
 }

--- a/app/src/main/res/layout/fragment_person_detail.xml
+++ b/app/src/main/res/layout/fragment_person_detail.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/dummy_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="PersonDetailFragment opened!"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_person_detail.xml
+++ b/app/src/main/res/layout/fragment_person_detail.xml
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/person_detail_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <TextView
-            android:id="@+id/dummy_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="PersonDetailFragment opened!"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/list_item_detail" />
 
 </layout>

--- a/app/src/main/res/layout/list_item_detail.xml
+++ b/app/src/main/res/layout/list_item_detail.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="detailItem"
+            type="com.davidread.starwarsdatabase.model.view.DetailListItem" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/list_item_padding">
+
+        <TextView
+            android:id="@+id/detail_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{detailItem.label}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/name_detail_label" />
+
+        <TextView
+            android:id="@+id/detail_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{detailItem.value}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/detail_label"
+            tools:text="Luke Skywalker" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/navigation/nav_graph_category.xml
+++ b/app/src/main/res/navigation/nav_graph_category.xml
@@ -5,11 +5,18 @@
     android:id="@+id/nav_graph_category"
     app:startDestination="@id/people_list_fragment">
 
+    <!-- Top-level fragment destinations. -->
     <fragment
         android:id="@+id/people_list_fragment"
         android:name="com.davidread.starwarsdatabase.view.PeopleListFragment"
         android:label="@string/people_list_fragment_name"
-        tools:layout="@layout/fragment_people_list" />
+        tools:layout="@layout/fragment_people_list">
+
+        <action
+            android:id="@+id/action_peopleListFragment_to_personDetailFragment"
+            app:destination="@id/person_detail_fragment" />
+
+    </fragment>
 
     <fragment
         android:id="@+id/films_list_fragment"
@@ -75,5 +82,12 @@
             app:argType="reference" />
 
     </fragment>
+
+    <!-- 2nd-level fragment destinations. -->
+    <fragment
+        android:id="@+id/person_detail_fragment"
+        android:name="com.davidread.starwarsdatabase.view.PersonDetailFragment"
+        android:label="@string/person_detail_fragment_name"
+        tools:layout="@layout/fragment_person_detail" />
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,9 @@
     <!-- PlanetsListFragment strings. -->
     <string name="planets_list_fragment_name">Planets</string>
 
+    <!-- PersonDetailFragment strings. -->
+    <string name="person_detail_fragment_name">Person Details</string>
+
     <!-- List item strings. -->
     <string name="fetch_items_error_message">Error fetching items</string>
     <string name="retry_button_label">Retry</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,21 @@
     <!-- PersonDetailFragment strings. -->
     <string name="person_detail_fragment_name">Person Details</string>
 
+    <!-- Detail label strings. -->
+    <string name="name_detail_label">Name</string>
+    <string name="homeworld_detail_label">Homeworld</string>
+    <string name="birth_year_detail_label">Birth Year</string>
+    <string name="species_detail_label">Species</string>
+    <string name="gender_detail_label">Gender</string>
+    <string name="height_detail_label">Height</string>
+    <string name="mass_detail_label">Mass</string>
+    <string name="hair_color_detail_label">Hair Color</string>
+    <string name="eye_color_detail_label">Eye Color</string>
+    <string name="skin_color_detail_label">Skin Color</string>
+    <string name="films_detail_label">Films</string>
+    <string name="starships_detail_label">Starships</string>
+    <string name="vehicles_detail_label">Vehicles</string>
+
     <!-- List item strings. -->
     <string name="fetch_items_error_message">Error fetching items</string>
     <string name="retry_button_label">Retry</string>


### PR DESCRIPTION
# Changelog
- 76a7ea807ffdc287afab14f785375663a63cccdb
    - Open dummy ```PersonDetailFragment``` on person click in ```PeopleListFragment```.
    - Ensure ```CategoryActivity``` navigation drawer and nav graph play well with a 2nd level fragment destination.
- 738ee72e897d2280dcfe1a57a883b78e4fd884dc
    - Fix bug where ```PeopleListFragment``` would request duplicate people from SWAPI because the ```RecyclerView``` ```OnScrollListener``` was never removed when navigating to ```PersonDetailFragment```.
- 3355233149c834e774222fad3c76a09938703ffc
    - Fill ```PersonDetailFragment``` UI with a dummy ```RecyclerView``` list of person details.

# Video
- [device-2022-12-10-204443.webm](https://user-images.githubusercontent.com/49120229/206882609-97ae1f2e-459b-4484-afd7-7cdfaf1851e7.webm)
