### PR TITLE
Move as many observers as possible from fragment to layout file

### DIFF
--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailsFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailsFragment.kt
@@ -63,7 +63,11 @@ class PersonDetailsFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding.personDetailsRetryButton.setOnClickListener { onErrorRetryClick() }
+        binding.apply {
+            lifecycleOwner = viewLifecycleOwner
+            personDetailsViewModel = viewModel
+            personDetailsRetryButton.setOnClickListener { onErrorRetryClick() }
+        }
         setupObservers()
         if (savedInstanceState == null) {
             viewModel.getPersonDetails(arguments.id)
@@ -80,22 +84,6 @@ class PersonDetailsFragment : Fragment() {
             binding.personDetailsList.apply {
                 adapter = ResourceDetailsAdapter(personDetails)
                 addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
-            }
-        }
-
-        viewModel.showLoadingLiveData.observe(viewLifecycleOwner) { showLoading ->
-            binding.personDetailsProgressBar.visibility = if (showLoading) {
-                View.VISIBLE
-            } else {
-                View.GONE
-            }
-        }
-
-        viewModel.showErrorLiveData.observe(viewLifecycleOwner) { showError ->
-            binding.personDetailsErrorLayout.visibility = if (showError) {
-                View.VISIBLE
-            } else {
-                View.GONE
             }
         }
     }

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailsFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PersonDetailsFragment.kt
@@ -68,7 +68,7 @@ class PersonDetailsFragment : Fragment() {
             personDetailsViewModel = viewModel
             personDetailsRetryButton.setOnClickListener { onErrorRetryClick() }
         }
-        setupObservers()
+        setupObserver()
         if (savedInstanceState == null) {
             viewModel.getPersonDetails(arguments.id)
         }
@@ -76,10 +76,10 @@ class PersonDetailsFragment : Fragment() {
     }
 
     /**
-     * Sets up an observer to [ResourceDetailsAdapter]'s dataset, to this fragment's loading state,
-     * and this fragment's error state.
+     * Sets up observers for the fragment.
      */
-    private fun setupObservers() {
+    private fun setupObserver() {
+        // Updates the adapter with the dataset when it becomes available.
         viewModel.personDetailsLiveData.observe(viewLifecycleOwner) { personDetails ->
             binding.personDetailsList.apply {
                 adapter = ResourceDetailsAdapter(personDetails)

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PersonNamesFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PersonNamesFragment.kt
@@ -96,7 +96,7 @@ class PersonNamesFragment : Fragment() {
             adapter = personNamesAdapter
             addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
         }
-        setupObserver()
+        setupObservers()
         return binding.root
     }
 
@@ -110,17 +110,15 @@ class PersonNamesFragment : Fragment() {
     }
 
     /**
-     * Sets up an observer to the [ResourceNamesAdapter]'s dataset. It sets up two observers. The
-     * first one is responsible for updating the adapter with the latest dataset from the
-     * [viewModel]. The second is responsible for removing the scroll listener from the
-     * [RecyclerView] when no more entries may be fetched for the dataset.
+     * Sets up observers for the fragment.
      */
-    private fun setupObserver() {
+    private fun setupObservers() {
         viewModel.personNamesLiveData.observe(viewLifecycleOwner) { personNames ->
-            /* Shallow copy of the dataset needed for DiffCallback to calculate diffs of the old and
-             * new lists. */
+            /* Submit a deep copy of the dataset to the adapter. DiffCallback believes a shallow
+             * copy of the dataset is the same dataset. */
             personNamesAdapter.submitList(personNames.toList())
 
+            // Take some action depending on the last item of the new dataset.
             when (personNames.lastOrNull()) {
                 is ResourceNameListItem.ResourceName -> {
                     binding.personNamesList.addOnScrollListener(loadMorePersonNamesOnScrollListener)
@@ -132,6 +130,7 @@ class PersonNamesFragment : Fragment() {
             }
         }
 
+        // Removes the scroll listener when the dataset has fetched all list items.
         viewModel.isAllPersonNamesRequestedLiveData.observe(viewLifecycleOwner) { isAllPersonNamesRequested ->
             if (isAllPersonNamesRequested) {
                 binding.personNamesList.removeOnScrollListener(loadMorePersonNamesOnScrollListener)

--- a/app/src/main/res/layout/fragment_person_details.xml
+++ b/app/src/main/res/layout/fragment_person_details.xml
@@ -4,6 +4,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".view.PersonDetailsFragment">
 
+    <data>
+
+        <import type="android.view.View" />
+
+        <variable
+            name="personDetailsViewModel"
+            type="com.davidread.starwarsdatabase.viewmodel.PersonDetailsViewModel" />
+
+    </data>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -22,14 +32,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:visibility="gone" />
+            android:visibility="@{personDetailsViewModel.showLoadingLiveData ? View.VISIBLE : View.GONE}" />
 
         <!-- Error state. -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/person_details_error_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="gone">
+            android:visibility="@{personDetailsViewModel.showErrorLiveData ? View.VISIBLE : View.GONE}">
 
             <TextView
                 android:id="@+id/person_details_error_message"

--- a/app/src/main/res/layout/fragment_person_details.xml
+++ b/app/src/main/res/layout/fragment_person_details.xml
@@ -32,14 +32,16 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:visibility="@{personDetailsViewModel.showLoadingLiveData ? View.VISIBLE : View.GONE}" />
+            android:visibility="@{personDetailsViewModel.showLoadingLiveData ? View.VISIBLE : View.GONE}"
+            tools:visibility="gone" />
 
         <!-- Error state. -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/person_details_error_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:visibility="@{personDetailsViewModel.showErrorLiveData ? View.VISIBLE : View.GONE}">
+            android:visibility="@{personDetailsViewModel.showErrorLiveData ? View.VISIBLE : View.GONE}"
+            tools:visibility="gone">
 
             <TextView
                 android:id="@+id/person_details_error_message"

--- a/app/src/main/res/layout/fragment_person_names.xml
+++ b/app/src/main/res/layout/fragment_person_names.xml
@@ -8,6 +8,7 @@
         android:id="@+id/person_names_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/list_item_resource_name" />
 
 </layout>


### PR DESCRIPTION
# Changelog
- a62ce6c3f3cf51b09fcaeee6fe2d251af02c7f16
    - Move showLoadingLiveData and showErrorLiveData observers from PersonDetailsFragment.kt -> fragment_person_details.xml.
- 094339f8f7f81fa8735f410f8d11a9500ab72b97
    - Update documentation for observers in each fragment.
- cbe954f25f39132f4b79051360707398f219092a
    - Update fragment layout files to use tools attributes to make layout preview better reflect what the actual layout looks like on an actual device.