### PR TITLE
Persist next page number in PersonNamesViewModelImpl

### DIFF
--- a/app/src/main/java/com/davidread/starwarsdatabase/util/Extensions.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/util/Extensions.kt
@@ -44,6 +44,24 @@ fun List<String>.extractIDsFromURLs(): List<Int> {
 }
 
 /**
+ * Takes a [String] that matches the URL `https://swapi.dev/api/{endpoint}/?page={pageInt}` and
+ * returns the `{pageInt}` field as an [Int].
+ *
+ * @throws IllegalArgumentException Thrown when the [String] does not match the URL regular
+ * expression.
+ */
+fun String.extractPageFromURL(): Int {
+    val regex = "https://swapi\\.dev/api/[a-z]+/\\?page=(\\d+)"
+    val pattern = Pattern.compile(regex)
+    val matcher = pattern.matcher(this)
+    return if (matcher.matches()) {
+        matcher.group(1)!!.toInt()
+    } else {
+        throw IllegalArgumentException("$this must match the regular expression $regex")
+    }
+}
+
+/**
  * Takes a [List] of [ResourceResponse] and returns a [String] comma-delimited list of each object's
  * `name` or `title` field.
  */

--- a/app/src/main/java/com/davidread/starwarsdatabase/view/PersonNamesFragment.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/view/PersonNamesFragment.kt
@@ -68,8 +68,7 @@ class PersonNamesFragment : Fragment() {
 
             if (isLastItemVisible) {
                 recyclerView.removeOnScrollListener(this)
-                val page = ((totalItemCount - 1) / 10) + 2
-                viewModel.getPersonNames(page)
+                viewModel.getPersonNames(viewModel.nextPage)
             }
         }
     }
@@ -156,7 +155,6 @@ class PersonNamesFragment : Fragment() {
      * people from the [viewModel] to be added onto the dataset from SWAPI.
      */
     private fun onErrorRetryClick() {
-        val page = ((personNamesAdapter.itemCount - 2) / 10) + 2
-        viewModel.getPersonNames(page)
+        viewModel.getPersonNames(viewModel.nextPage)
     }
 }

--- a/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PersonNamesViewModel.kt
+++ b/app/src/main/java/com/davidread/starwarsdatabase/viewmodel/PersonNamesViewModel.kt
@@ -10,5 +10,7 @@ import com.davidread.starwarsdatabase.model.view.ResourceNameListItem
 interface PersonNamesViewModel {
     val personNamesLiveData: LiveData<List<ResourceNameListItem>>
     val isAllPersonNamesRequestedLiveData: LiveData<Boolean>
+    @setparam:IntRange(from = 1)
+    var nextPage: Int
     fun getPersonNames(@IntRange(from = 1) page: Int)
 }

--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PersonNamesViewModelImplTest.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PersonNamesViewModelImplTest.kt
@@ -94,6 +94,40 @@ class PersonNamesViewModelImplTest {
         Assert.assertFalse(viewModel.isAllPersonNamesRequestedLiveData.value!!)
     }
 
+    @Test
+    fun `given datasource that returns a success next URL, when viewmodel calls init, then viewmodel increments nextPage`() {
+        val next = "https://swapi.dev/api/people/?page=2"
+        val response = getSuccessfulPageResponseOfPeople(next)
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.just(response)
+        }
+        val viewModel = PersonNamesViewModelImpl(dataSource)
+
+        Assert.assertEquals(2, viewModel.nextPage)
+    }
+
+    @Test
+    fun `given datasource that returns a null next URL, when viewmodel calls init, then viewmodel does not increment nextPage`() {
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.error(Throwable())
+        }
+        val viewModel = PersonNamesViewModelImpl(dataSource)
+
+        Assert.assertEquals(1, viewModel.nextPage)
+    }
+
+    @Test
+    fun `given datasource that returns an incorrect next URL, when viewmodel calls init, then viewmodel does not increment nextPage`() {
+        val next = "Oops I am not a URL"
+        val response = getSuccessfulPageResponseOfPeople(next)
+        val dataSource = mockk<PeopleRemoteDataSource> {
+            every { getPeople(any()) } returns Single.just(response)
+        }
+        val viewModel = PersonNamesViewModelImpl(dataSource)
+
+        Assert.assertEquals(1, viewModel.nextPage)
+    }
+
     private fun getSuccessfulPageResponseOfPeople(next: String? = null): PageResponse<ResourceResponse.Person> {
         val results = listOf<ResourceResponse.Person>(
             mockk {


### PR DESCRIPTION
# Changelog
- bf204abf624b648632b4bf369fa9cef4183bfff3
    - Add extension function for extracting the page parameter of an SWAPI URL.
- dd8cc9aa921ffb64e5f0432a4c67339d3669256a
    - Persist the next page of person names to request from SWAPI in PersonNamesViewModelImpl.kt and use it in PersonNamesFragment.kt instead of calculating the value.
- ce451e8390b15cf891f06bb222d8fcc55537a655
    - Add unit tests for new PersonNamesViewModelImpl.kt#nextPage property.