### PR TITLE
Move common view model unit test logic into a base class

### DIFF
--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/BaseViewModelImplTest.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/BaseViewModelImplTest.kt
@@ -1,0 +1,29 @@
+package com.davidread.starwarsdatabase.viewmodel
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.davidread.starwarsdatabase.RxImmediateSchedulerRule
+import org.junit.Rule
+
+/**
+ * Base class for `...ViewModelImplTest` classes to inherit. Provides rules for the inheriting test
+ * class to use in order for it to conduct unit tests on `ViewModel` subclasses that use
+ * Architecture Components and RxJava.
+ */
+abstract class BaseViewModelImplTest {
+
+    /**
+     * Rule that swaps the background executor used by the Architecture Components with one that
+     * executes each task synchronously.
+     */
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    /**
+     * Rule that forces RxJava to execute it's load on the main thread.
+     */
+    @Rule
+    @JvmField
+    val testSchedulerRule = RxImmediateSchedulerRule()
+
+}

--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/BaseViewModelImplTest.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/BaseViewModelImplTest.kt
@@ -1,7 +1,6 @@
 package com.davidread.starwarsdatabase.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.davidread.starwarsdatabase.RxImmediateSchedulerRule
 import org.junit.Rule
 
 /**

--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PersonDetailsViewModelImplTest.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PersonDetailsViewModelImplTest.kt
@@ -1,8 +1,6 @@
 package com.davidread.starwarsdatabase.viewmodel
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.davidread.starwarsdatabase.R
-import com.davidread.starwarsdatabase.RxImmediateSchedulerRule
 import com.davidread.starwarsdatabase.datasource.*
 import com.davidread.starwarsdatabase.model.datasource.ResourceResponse
 import com.davidread.starwarsdatabase.model.view.ResourceDetailListItem
@@ -10,28 +8,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.reactivex.rxjava3.core.Single
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 
 /**
  * Unit tests that verify the correctness of [PersonDetailsViewModelImpl].
  */
-class PersonDetailsViewModelImplTest {
-
-    /**
-     * Rule that swaps the background executor used by the Architecture Components with one that
-     * executes each task synchronously.
-     */
-    @Rule
-    @JvmField
-    val instantExecutorRule = InstantTaskExecutorRule()
-
-    /**
-     * Rule that forces RxJava to execute it's load on the main thread.
-     */
-    @Rule
-    @JvmField
-    val testSchedulerRule = RxImmediateSchedulerRule()
+class PersonDetailsViewModelImplTest : BaseViewModelImplTest() {
 
     @Test
     fun `given that all datasources return success response, when viewmodel calls getPersonDetails(), then viewmodel emits the expected detail list items in the UI list`() {

--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PersonNamesViewModelImplTest.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/PersonNamesViewModelImplTest.kt
@@ -1,7 +1,5 @@
 package com.davidread.starwarsdatabase.viewmodel
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.davidread.starwarsdatabase.RxImmediateSchedulerRule
 import com.davidread.starwarsdatabase.datasource.PeopleRemoteDataSource
 import com.davidread.starwarsdatabase.model.datasource.PageResponse
 import com.davidread.starwarsdatabase.model.datasource.ResourceResponse
@@ -10,28 +8,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.reactivex.rxjava3.core.Single
 import org.junit.Assert
-import org.junit.Rule
 import org.junit.Test
 
 /**
  * Unit tests that verify the correctness of [PersonNamesViewModelImpl].
  */
-class PersonNamesViewModelImplTest {
-
-    /**
-     * Rule that swaps the background executor used by the Architecture Components with one that
-     * executes each task synchronously.
-     */
-    @Rule
-    @JvmField
-    val instantExecutorRule = InstantTaskExecutorRule()
-
-    /**
-     * Rule that forces RxJava to execute it's load on the main thread.
-     */
-    @Rule
-    @JvmField
-    val testSchedulerRule = RxImmediateSchedulerRule()
+class PersonNamesViewModelImplTest : BaseViewModelImplTest() {
 
     @Test
     fun `given datasource that returns success response, when viewmodel calls init, then viewmodel emits 10 person items in the UI list`() {

--- a/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/RxImmediateSchedulerRule.kt
+++ b/app/src/test/java/com/davidread/starwarsdatabase/viewmodel/RxImmediateSchedulerRule.kt
@@ -1,4 +1,4 @@
-package com.davidread.starwarsdatabase
+package com.davidread.starwarsdatabase.viewmodel
 
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.plugins.RxJavaPlugins


### PR DESCRIPTION
# Changelog
- 80be7c3d191cf86dcac6166689d351f4e3c73675
    - Move unit test rules into common BaseViewModelImplTest.kt for each ...ViewModelImplTest class to inherit.
- 7b33d55d1d5e2c69703c682a9188e8db003c4688
    - Move RxImmediateSchedulerRule.kt into the viewmodel package.